### PR TITLE
changed regex (math, list) & adjusted tests

### DIFF
--- a/MarkdownToLatex/MarkdownToLatex.Test/TestMarkdownParser.cs
+++ b/MarkdownToLatex/MarkdownToLatex.Test/TestMarkdownParser.cs
@@ -21,15 +21,17 @@ namespace MarkdownToLatex.Test
         }
 
         [Theory]
-        [InlineData("! f(x)=x^2+5*x-11/10:x", "f(x)=x^2+5*x-11/10:x")]
-        [InlineData("! f(99.12)=x^4+3*x^3-111/100:x", "f(99.12)=x^4+3*x^3-111/100:x")]
-        public void TestMatchMathElement(string teststr, string expText)
+        [InlineData("!{svfunc} f(x)=x^2+5*x-11/10:x !", "svfunc", "f(x)=x^2+5*x-11/10:x", "")]
+        [InlineData("!{mvfunc} f(99.12,0)=x^4+3*x^3-111/100-1.2*y:x,y !{result}{root}", "mvfunc", "f(99.12,0)=x^4+3*x^3-111/100-1.2*y:x,y", "{result}{root}")]
+        public void TestMatchMathElement(string teststr, string expType, string expText, string expParam)
         {
             //act
             Match result = MarkdownParser.MatchMathElement(teststr);
 
             //assert
-            Assert.Contains(expText, result.Groups[1].Value);
+            Assert.Equal(expType, result.Groups[1].Value);
+            Assert.Equal(expText, result.Groups[2].Value);
+            Assert.Equal(expParam, result.Groups[3].Value);
         }
 
         [Theory]
@@ -56,7 +58,7 @@ namespace MarkdownToLatex.Test
             Match result = MarkdownParser.MatchList(teststr);
             //assert
             Assert.Equal(expLevel, result.Groups[1].Length/2);
-            Assert.Contains(expText, result.Groups[3].Value);
+            Assert.Contains(expText, result.Groups[2].Value);
         }
 
         [Theory]
@@ -101,14 +103,9 @@ namespace MarkdownToLatex.Test
             Assert.Equal(matchCount, result.Count);
         }
 
-        /*  Error with RegEx
-        \textbf{*s*}a*a*\textbf{a*a*a}a\textbf{*a*a}a\textbf{a*a*}a*a\textbf{a}*a**a*a\textbf{a}a*a*\textbf{a}a*a*a\textbf{a}*
-        \textbf{*s*}a*a*\textbf{a*a*a}a\textbf{*a*a}a**a*a\textbf{*a*a}a*\textbf{a}a*a**a\textbf{a*a*}a\textbf{a*a*a}a***	        C#
-
-        a**a*a***a*a**a***a**a*a**a**a*a***a**a*a*a**a***
-        */
         [Theory]
         [InlineData("***s***a*a***a*a*a**a***a*a**a**a*a***a*a**a***a**a*a**a**a*a***a**a*a*a**a***", 8 + 9)] // bold + cursive
+        [InlineData("simple **bold**, *cursive* and ***bold+cursive***", 2 + 2)]
         public void TestMatchBoldAndCursive(string teststr, int matchCount)
         {
             //arrange
@@ -119,13 +116,13 @@ namespace MarkdownToLatex.Test
             int cursiveCounter;
 
             //act
+                //bold
             boldMatch = MarkdownParser.MatchBold(resultstr);
             boldCounter = boldMatch.Count;
 
             resultstr = MarkdownParser.TextRx["bold"].Replace(resultstr, @"\textbf{$2}");
 
-            // Replace is working wrong
-
+                //cursive
             cursiveMatch = MarkdownParser.MatchCursive(resultstr);
             cursiveCounter = cursiveMatch.Count;
 

--- a/MarkdownToLatex/MarkdownToLatex.Test/TestMarkdownParser.cs
+++ b/MarkdownToLatex/MarkdownToLatex.Test/TestMarkdownParser.cs
@@ -45,7 +45,7 @@ namespace MarkdownToLatex.Test
 
             //assert
             Assert.Equal(expType, result.Groups[1].Length);
-            Assert.Contains(expText, result.Groups[2].Value);
+            Assert.Equal(expText, result.Groups[2].Value);
         }
 
         [Theory]
@@ -58,7 +58,7 @@ namespace MarkdownToLatex.Test
             Match result = MarkdownParser.MatchList(teststr);
             //assert
             Assert.Equal(expLevel, result.Groups[1].Length/2);
-            Assert.Contains(expText, result.Groups[2].Value);
+            Assert.Equal(expText, result.Groups[2].Value);
         }
 
         [Theory]
@@ -71,7 +71,7 @@ namespace MarkdownToLatex.Test
             Match result = MarkdownParser.MatchQuote(teststr);
             //assert
             Assert.Equal(expDepth, result.Groups[1].Length);
-            Assert.Contains(expText, result.Groups[2].Value);
+            Assert.Equal(expText, result.Groups[2].Value);
         }
 
         [Theory]

--- a/MarkdownToLatex/MarkdownToLatex/MarkdownParser.cs
+++ b/MarkdownToLatex/MarkdownToLatex/MarkdownParser.cs
@@ -19,14 +19,14 @@ namespace MarkdownToLatex
         public static Dictionary<string, Regex> TextRx {get;}
 
         //methods
-        /// <summary>Reads lines of document from given file path. The resulting array is saved to <see cref="MdLines"/>.
+        /// <summary>Reads lines of document from <paramref name="mdFilePath">. The resulting array is saved to <see cref="MdLines"/>.
         /// <seealso cref="MdToTex.parsePath()"></seealso></summary>
         public static void ReadMdDocument(string mdFilePath)
         {
             MdLines = File.ReadAllLines(mdFilePath);
         }
 
-        /// <summary>Matches math element in Markdown with a custom "! " operator.</summary>
+        /// <summary>Matches math element in Markdown with a custom "!{} " operator.</summary>
         /// <returns>Match with the math element in Group[1].</returns>
         public static Match MatchMathElement(string line)
         {
@@ -74,9 +74,9 @@ namespace MarkdownToLatex
         {
             TextRx = new Dictionary<string, Regex>()
             {
-                {"math", new Regex(@"^! (.+)")},
+                {"math", new Regex(@"^!{([^{}]+)} (.+) !((?:{[^{}]+})*)")},
                 {"headline", new Regex(@"^(#+) (.+)")},
-                {"list", new Regex(@"^((  )*)[-*+] (.+)")},
+                {"list", new Regex(@"^((?:  )*)[-*+] (.+)")},
                 {"quote", new Regex(@"^(>+) (.+)")},
                 {"cursive", new Regex(@"(\*|_)([^\*_]+?|[^\*_]*?(\*\*|__)[^\*_]+?(\*\*|__)[^\*_]*?)(\1)")},
                 {"bold", new Regex(@"(\*\*|__)([^\*_]+?|[^\*_]*?(\*|_)[^\*_]+?(\*|_)[^\*_]*?)(\1)")}


### PR DESCRIPTION
Ich habs jetzt einfach mal gemacht mit den Parametern von und hinten.
Im [Wiki](https://github.com/fb89zila/exam-repo_swe-sose21/wiki/Developer#used-regular-expressions-) hab ich die Änderungen schon mal getroffen, da die Gruppennummerierung sich jetzt glaube nicht mehr ändert.

PS: Ich hab herausgefunden wie man non-capturing Groups in RegEx benutzt, also hab ich bei den Listen jetzt wieder Gruppe 2 als den Inhalt. Sorry das sich das wieder ändert.