### PR TITLE
convertMathElement

### DIFF
--- a/MarkdownToLatex/MarkdownToLatex.Test/TestCalculators.cs
+++ b/MarkdownToLatex/MarkdownToLatex.Test/TestCalculators.cs
@@ -10,7 +10,7 @@ namespace MarkdownToLatex.Test
             FuncCalculator calc = new FuncCalculator("x", "2*x^3-7*x^2+5*x-3", 13.37);
             string result = calc.Calculate();
 
-            Assert.Equal("f(x)=3592.51", result);
+            Assert.Equal("f(13.37)=3592.51", result);
         }
 
         [Theory]

--- a/MarkdownToLatex/MarkdownToLatex.Test/TestLatexRenderer.cs
+++ b/MarkdownToLatex/MarkdownToLatex.Test/TestLatexRenderer.cs
@@ -118,6 +118,13 @@ namespace MarkdownToLatex.Test
         [Fact]
         public void TestWriteLatexDocument(){
             //arrange
+            LatexRenderer.LatexLines.Clear();
+            string[] input = {
+                @"\chapter*{A nice Chapter}",
+                @"\section*{A nicer Section}",
+                @"\subsection*{vërÿ wëïrd ïnpüt}",
+                @"\subsection*{An even nicer Subsection}"
+            };
             string expPath = @"test_files/latex/test.tex";
             string[] expected = {
                 @"\documentclass{scrreprt}",
@@ -133,6 +140,7 @@ namespace MarkdownToLatex.Test
             };
 
             //act
+            LatexRenderer.LatexLines.AddRange(input);
             LatexRenderer.WriteLatexDocument(expPath);
             string[] result = File.ReadAllLines(expPath);
 

--- a/MarkdownToLatex/MarkdownToLatex.Test/TestMdToTex.cs
+++ b/MarkdownToLatex/MarkdownToLatex.Test/TestMdToTex.cs
@@ -25,7 +25,7 @@ namespace MarkdownToLatex.Test
         }
         
         [Fact]
-        public void TestConvert()
+        public void TestConvertMathElement()
         {
             //arrange
             LatexRenderer.LatexLines.Clear();

--- a/MarkdownToLatex/MarkdownToLatex.Test/TestMdToTex.cs
+++ b/MarkdownToLatex/MarkdownToLatex.Test/TestMdToTex.cs
@@ -28,8 +28,20 @@ namespace MarkdownToLatex.Test
         public void TestConvert()
         {
             //arrange
+            LatexRenderer.LatexLines.Clear();
+            string mathElement = "!{svfunc} f(3.1415)=x^2+3*x+5:x !{result}";
+            string[] expected = {
+                @"\[f(x)=5 + 3x + {x}^{2}\]",
+                @"\[f(3.1415)=24.29\]"
+            };
+
             //act
+            MdToTex.convertMathElement(MarkdownParser.MatchMathElement(mathElement));
+
             //assert
+            foreach(string expLine in expected){
+                Assert.Contains(expLine, LatexRenderer.LatexLines);
+            }
         }
     }
 }

--- a/MarkdownToLatex/MarkdownToLatex/FuncCalculator.cs
+++ b/MarkdownToLatex/MarkdownToLatex/FuncCalculator.cs
@@ -12,7 +12,7 @@ namespace MarkdownToLatex {
         public string Calculate(int precision = 2){
             try{
                 var func = Expr.Parse(this.Element);
-                return $"f({this.Var})=" + Math.Round(func.Compile(this.Var)(this.Param ?? 0), precision).ToString(CultureInfo.InvariantCulture);
+                return $"f({this.Param ?? 0})=" + Math.Round(func.Compile(this.Var)(this.Param ?? 0), precision).ToString(CultureInfo.InvariantCulture);
             } catch (Exception ex){
                 throw new ConvertElementException("Error calculating function!", ex);
             }

--- a/MarkdownToLatex/MarkdownToLatex/FuncCalculator.cs
+++ b/MarkdownToLatex/MarkdownToLatex/FuncCalculator.cs
@@ -12,7 +12,7 @@ namespace MarkdownToLatex {
         public string Calculate(int precision = 2){
             try{
                 var func = Expr.Parse(this.Element);
-                return $"f({this.Param ?? 0})=" + Math.Round(func.Compile(this.Var)(this.Param ?? 0), precision).ToString(CultureInfo.InvariantCulture);
+                return $"f({(this.Param ?? 0).ToString(CultureInfo.InvariantCulture)})=" + Math.Round(func.Compile(this.Var)(this.Param ?? 0), precision).ToString(CultureInfo.InvariantCulture);
             } catch (Exception ex){
                 throw new ConvertElementException("Error calculating function!", ex);
             }

--- a/MarkdownToLatex/MarkdownToLatex/LatexRenderer.cs
+++ b/MarkdownToLatex/MarkdownToLatex/LatexRenderer.cs
@@ -62,7 +62,7 @@ namespace MarkdownToLatex
 
         /// <summary>Writes a MathElement in LaTeX.</summary>
         public static void WriteMathElement(string line){
-            LatexLines.Add(line); //The calculation stuff is handled in MdToTex class
+            LatexLines.Add(@"\[" + line + @"\]"); //The calculation stuff is handled in MdToTex class
         }
 
         /// <summary>Writes a Headline in LaTeX using a Match <paramref name="m"/>.</summary>


### PR DESCRIPTION
Ok, folgendes ist enthalten:
* Die `convertMathElement()`-Methode
* Die `Calculate()` Methode gibt jetzt statt z.B. `f(x)=12.7` auch `f(3.2)=12.7` aus, da die Funktion ja eh ne Zeile drüber steht und man so auch weiß, was überhaupt eingesetzt wurde
* Im `LatexRenderer` hab ich zur `WriteMathElement` noch die LaTeX_Tags für Formeln hinzugefügt
* Ich musste den `TestWriteLatexDocument()` Test anpassen, da durch den `TestConvert()` Test der Inhalt nicht mehr gestimmt hat

Das müsste alles gewesen sein