### PR TITLE
Update LaTeX Path + Adjust Tests

### DIFF
--- a/MarkdownToLatex/MarkdownToLatex.Test/TestLatexRenderer.cs
+++ b/MarkdownToLatex/MarkdownToLatex.Test/TestLatexRenderer.cs
@@ -16,6 +16,7 @@ namespace MarkdownToLatex.Test
         [InlineData("#### vërÿ wëïrd ïnpüt", @"\subsection*{vërÿ wëïrd ïnpüt}")]
         public void TestWriteHeadline(string mdline, string expected){
             //arrange
+            LatexRenderer.LatexLines.Clear();
             string line = mdline;
 
             //act
@@ -152,6 +153,7 @@ namespace MarkdownToLatex.Test
         [Fact]
         public void TestWriteText(){
             //arrange
+            LatexRenderer.LatexLines.Clear();
             string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 ";
             string randomText = "";
             int randomTextLength = rnd.Next(1, 256);

--- a/MarkdownToLatex/MarkdownToLatex/LatexRenderer.cs
+++ b/MarkdownToLatex/MarkdownToLatex/LatexRenderer.cs
@@ -44,9 +44,9 @@ namespace MarkdownToLatex
             if(Path.GetExtension(path) == ".tex"){
                 latexPath = path;
             } else if (Path.GetExtension(path) == ".md"){
-                latexPath = Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path) + ".tex");
+                latexPath = Path.Combine(Path.GetDirectoryName(path), "latex", Path.GetFileNameWithoutExtension(path), ".tex");
             } else {
-                latexPath = Path.Combine(path, Path.GetFileNameWithoutExtension(MdToTex.mdFilePath) + ".tex");
+                latexPath = Path.Combine(path, Path.GetFileNameWithoutExtension(MdToTex.mdFilePath), ".tex");
             }
             Directory.CreateDirectory(Path.GetDirectoryName(latexPath));
 


### PR DESCRIPTION
Mit diesem Pull-Request habe ich den Pfad für das LaTeX-Dokument angepasst (https://github.com/fb89zila/exam-repo_swe-sose21/issues/18#issuecomment-882434668) und bei jedem Test, der in irgendeiner weise was mit der `LatexLines` Liste macht ein `Clear()` zu Beginn eingefügt, weil ich die Vermutung hatte, dass das mysteriöse Phänomen daran liegt, dass noch von vorherigen Tests Überreste in der Liste sind.
Und falls die Vermutung nicht stimmen sollte, schadet es ja sowieso nix, die Liste vor jedem Test zu leeren^^