### PR TITLE
Display Error Message on Converting or Calculating a Function

### DIFF
--- a/MarkdownToLatex/MarkdownToLatex/FuncCalculator.cs
+++ b/MarkdownToLatex/MarkdownToLatex/FuncCalculator.cs
@@ -14,7 +14,7 @@ namespace MarkdownToLatex {
                 var func = Expr.Parse(this.Element);
                 return $"f({(this.Param ?? 0).ToString(CultureInfo.InvariantCulture)})=" + Math.Round(func.Compile(this.Var)(this.Param ?? 0), precision).ToString(CultureInfo.InvariantCulture);
             } catch (Exception ex){
-                throw new ConvertElementException("Error calculating function!", ex);
+                throw new ConvertElementException($"Error calculating function: {ex.Message}", ex);
             }
         }
 
@@ -25,7 +25,7 @@ namespace MarkdownToLatex {
                 var func = Expr.Parse(this.Element);
                 return $"f({this.Var})=" + func.ToLaTeX();
             } catch (Exception ex){
-                throw new ConvertElementException("Error converting function!", ex);
+                throw new ConvertElementException($"Error converting function: {ex.Message}", ex);
             }
         }
 


### PR DESCRIPTION
Ok, ich habe gesucht und bin zu dem Ergebnis gekommen, dass anscheinend Wirklich in `MathNet.Symbolics` keine Exceptions vorhanden sind und nur die `Exception` mit ner Error-Message verwendet wird. Diese hab ich wenigstens noch mit eingebaut, damit der User direkt sehen kann, wo falsche Eingaben sind.