### PR TITLE
Add support for optional precision parameter

### DIFF
--- a/MarkdownToLatex/MarkdownToLatex.Test/TestCalculators.cs
+++ b/MarkdownToLatex/MarkdownToLatex.Test/TestCalculators.cs
@@ -8,7 +8,7 @@ namespace MarkdownToLatex.Test
         public void TestCalculateFunction()
         {
             FuncCalculator calc = new FuncCalculator("x", "2*x^3-7*x^2+5*x-3");
-            string result = calc.Calculate(13.37);
+            string result = calc.Calculate(13.37, 2);
 
             Assert.Equal("f(13.37)=3592.51", result);
         }

--- a/MarkdownToLatex/MarkdownToLatex/FuncCalculator.cs
+++ b/MarkdownToLatex/MarkdownToLatex/FuncCalculator.cs
@@ -9,7 +9,7 @@ namespace MarkdownToLatex {
 
         /// <summary>Calculates the function at the given <paramref name="param"/>.
         /// The <paramref name="precision"/> paameter specifies the rounding accuracy.</summary>
-        public string Calculate(double param, int precision = 2){
+        public string Calculate(double param, int precision){
             try{
                 var func = Expr.Parse(this.Element);
                 return $"f({(param).ToString(CultureInfo.InvariantCulture)})=" + Math.Round(func.Compile(this.Var)(param), precision).ToString(CultureInfo.InvariantCulture);

--- a/MarkdownToLatex/MarkdownToLatex/MathParser.cs
+++ b/MarkdownToLatex/MarkdownToLatex/MathParser.cs
@@ -25,7 +25,7 @@ namespace MarkdownToLatex {
             MathRx = new Dictionary<string, Regex>()
             {
                 {"svfunction", new Regex(@"f\(([a-z]|[\d\.]+)\)=(.*):([a-z])")},
-                {"params", new Regex(@"(?:{(?:([^{}\(\)]+)(?:\(((?:,?[\-\d\.]+)*)\))?)})")}
+                {"params", new Regex(@"(?:{(?:([^{}\(\)]+)(?:\(((?:,?[\-\d\.]+)*)\))?(?:\[([\d]*)\])?)})")}
             };
         }
     }

--- a/MarkdownToLatex/MarkdownToLatex/MdToTex.cs
+++ b/MarkdownToLatex/MarkdownToLatex/MdToTex.cs
@@ -35,9 +35,11 @@ namespace MarkdownToLatex
                     foreach(Match m in mc){
                         switch(m.Groups[1].Value){
                             case "result":
-                                double param;
+                                double param; 
+                                int precision;
                                 bool hasParam = double.TryParse(m.Groups[2].Value, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out param);
-                                LatexRenderer.WriteMathElement((calc as FuncCalculator).Calculate(hasParam ? param : 0));
+                                bool hasPrecision = int.TryParse(m.Groups[3].Value, out precision);
+                                LatexRenderer.WriteMathElement((calc as FuncCalculator).Calculate(hasParam ? param : 0, hasPrecision ? precision : 2));
                                 break;
                         }
                     }


### PR DESCRIPTION
Ich hab mal als Standardwert (Falls keine vernünftige Zahl angegeben wurde) wieder die 2 gesetzt